### PR TITLE
Fix Lighting Issues with Chance Rendering

### DIFF
--- a/src/main/java/vfyjxf/gregicprobe/integration/gregtech/RecipeOutputInfoProvider.java
+++ b/src/main/java/vfyjxf/gregicprobe/integration/gregtech/RecipeOutputInfoProvider.java
@@ -27,6 +27,7 @@ import mcjty.theoneprobe.api.*;
 import mcjty.theoneprobe.apiimpl.elements.ElementItemStack;
 import mcjty.theoneprobe.apiimpl.styles.ItemStyle;
 import mcjty.theoneprobe.apiimpl.styles.LayoutStyle;
+import mcjty.theoneprobe.rendering.RenderHelper;
 import vfyjxf.gregicprobe.config.GregicProbeConfig;
 import vfyjxf.gregicprobe.element.*;
 import vfyjxf.gregicprobe.mixin.helper.AccessorAbstractRecipeLogic;
@@ -192,23 +193,15 @@ public class RecipeOutputInfoProvider extends CapabilityInfoProvider<IWorkable> 
 
     @SideOnly(Side.CLIENT)
     public static void renderChance(int chance, int x, int y) {
-        GlStateManager.disableLighting();
-        GlStateManager.disableDepth();
-        GlStateManager.disableBlend();
-
         GlStateManager.pushMatrix();
         GlStateManager.scale(0.5f, 0.5f, 1);
         Minecraft mc = Minecraft.getMinecraft();
 
         String chanceTxt = formatChance(chance);
-        mc.fontRenderer.drawStringWithShadow(chanceTxt, (x + 17) * 2 - 1 - mc.fontRenderer.getStringWidth(chanceTxt),
-                y * 2, 0xffffffff);
+        RenderHelper.renderText(mc, (x + 17) * 2 - 1 - mc.fontRenderer.getStringWidth(chanceTxt),
+                y * 2, chanceTxt);
 
         GlStateManager.popMatrix();
-
-        GlStateManager.enableLighting();
-        GlStateManager.enableDepth();
-        GlStateManager.enableBlend();
     }
 
 


### PR DESCRIPTION
This PR fixes the rendering of chances causing lighting to be enabled, causing weird issues when not showing detailed information (see below)

Chanced, without detail:
<img width="249" height="178" alt="image" src="https://github.com/user-attachments/assets/9160595f-b28b-4173-8c34-5ef79c22c7eb" />

Chanced, with detail:
<img width="249" height="178" alt="image" src="https://github.com/user-attachments/assets/72a45f04-48bd-4994-8a5c-850e86ced9a4" />

As can be observed, chanced rendering without detail causes the progress bar to be lighter than normal (with detail causes the normal color to be rendered)

**Note:** This is a direct port of https://github.com/Nomi-CEu/Nomi-Labs/commit/977ea31b28009fad18bcee4e56cca721591ee469. The changes have not been directly tested; so once this PR is merged (or before), testing should be performed.